### PR TITLE
[DONOT MERGE] MVP-23284: Retry method stress test 

### DIFF
--- a/api/v2/lib/Aspose.js
+++ b/api/v2/lib/Aspose.js
@@ -15,7 +15,7 @@ const storageApi = global.storageApiMap[uId] || new StorageApi(config)
 global.storageApiMap[uId] = storageApi
 global.staticToken = null
 
-const downloadFile = (name, folder, format, outPath) => {
+const downloadFile = (name, folder, format, outPath, hasWait) => {
   return new Promise((resolve, reject) => {
     const type = (name.endsWith('.docx') || name.endsWith('.doc')) ? 'v4.0/words' : 'v3.0/cells'
     const options = {
@@ -34,7 +34,15 @@ const downloadFile = (name, folder, format, outPath) => {
       res.pipe(file)
       res.on('end', () => {
         file.end()
-        setTimeout(resolve, 500)
+        // TODO: Remove
+        if (hasWait) {
+          setTimeout(() => {
+            reject('force timeout failed')
+            fs.unlinkSync(outPath)
+          }, 30 * 1000);
+        } else {
+          setTimeout(resolve, 500)
+        }
       })
     })
     req.on('error', (e) => {


### PR DESCRIPTION
#### Goal
- To see if retry + timeout will hold the thread and cause the incoming calls to delay.

#### Implement 
- A test flag `hasWait` inside the payload so it keeps the `Aspose.downloadFile` wait 30 secs with 3 tries and finally forced to fail.

#### Test 
- Test with 5 hasWait calls followed by 5 non-hasWait calls.
```
{
  "sessionId": "00Dj00000029O3fEAE!ARMAQBG5bccBQv2AhaSrVQ00ah5lbTAcj3lDLvGzT1rjX4kv1Gw8uyJ38KvjbycTQVwa9NP5e5IzlAnE2VJVwy4vUxPfEdK7",
  "orgId": "00Dj00000029O3fEAE",
  "hostUrl": "na159.salesforce.com",
  "namespace": "PLMDEV3",
  "documents": [
    {
      "templateVersionId": "0685b00000haZpzAAE",
      "templateName": "Logs.xlsx",
      "templateExtension": "xlsx",
      "stamps": {
        "footerCenterText": "Foooooooooooooter",
        "watermarkText": "Released6"
      },
      "pdfDocumentId": "0695b00000fz61DAAQ",
      "itemRevisionId": "a045b0000211myVAAQ",
      "itemId": "a005b00000yIqKwAAK",
      "hasWait": true / false
    }
  ]
}
```

#### Result 
- Each call is completely separated as the 5 non-hasWait went through before the first 5 calls

#### Log
- Take a look at the 7th call with `cf77a369a2c59438c2c95b5865b75b674445360f` is has started uploading before any retry from the first 5 calls.

```
router]: at=info method=POST path="/v2/watermark" host=propel-document-staging.herokuapp.com request_id=6ed44583-754c-499b-b81c-49ee95897d73 fwd="98.234.38.231" dyno=web.1 connect=0ms service=1ms status=200 bytes=209 protocol=https
[web.1]: >>> convert : Logs.xlsx : 4f1ea591f0f110a2377b9f79a5232aaecfac7071
router]: at=info method=POST path="/v2/watermark" host=propel-document-staging.herokuapp.com request_id=e141de35-d5ab-475a-b7c3-f11ee0215de9 fwd="98.234.38.231" dyno=web.1 connect=0ms service=1ms status=200 bytes=209 protocol=https
[web.1]: >>> convert : Logs.xlsx : b510db7dccc212e4d8e2933b85cf6aed4cc1a86d
router]: at=info method=POST path="/v2/watermark" host=propel-document-staging.herokuapp.com request_id=1f3b850a-3a4d-43a7-9b37-bec3ec1642f9 fwd="98.234.38.231" dyno=web.1 connect=0ms service=1ms status=200 bytes=209 protocol=https
[web.1]: >>> convert : Logs.xlsx : 416eb9f55f29bfba2bf072ca8ae02c616098f803
router]: at=info method=POST path="/v2/watermark" host=propel-document-staging.herokuapp.com request_id=17542b17-3475-48ef-aeb9-90716d6929af fwd="98.234.38.231" dyno=web.1 connect=0ms service=1ms status=200 bytes=209 protocol=https
[web.1]: >>> convert : Logs.xlsx : c6928e0624b67ba2961e911da8b6ae8499ba8368
router]: at=info method=POST path="/v2/watermark" host=propel-document-staging.herokuapp.com request_id=fa9ffb4f-6820-4fa4-83d7-004b19ca1687 fwd="98.234.38.231" dyno=web.1 connect=0ms service=1ms status=200 bytes=209 protocol=https
[web.1]: >>> convert : Logs.xlsx : 2a3f5c8db2a0c06dad8988ab5e0a3c08798ce3d7
router]: at=info method=POST path="/v2/watermark" host=propel-document-staging.herokuapp.com request_id=4563725b-98b2-4df6-8e84-23d80016deef fwd="98.234.38.231" dyno=web.1 connect=0ms service=1ms status=200 bytes=209 protocol=https
[web.1]: >>> convert : Logs.xlsx : 24bbf9769712877d3184480820586185c5008239
router]: at=info method=POST path="/v2/watermark" host=propel-document-staging.herokuapp.com request_id=5777fa87-f3de-4ac1-a6f9-ac0183181207 fwd="98.234.38.231" dyno=web.1 connect=0ms service=1ms status=200 bytes=209 protocol=https
[web.1]: >>> convert : Logs.xlsx : cf77a369a2c59438c2c95b5865b75b674445360f
router]: at=info method=POST path="/v2/watermark" host=propel-document-staging.herokuapp.com request_id=5ba58044-c939-4808-bca1-909b5183905d fwd="98.234.38.231" dyno=web.1 connect=0ms service=1ms status=200 bytes=209 protocol=https
[web.1]: >>> convert : Logs.xlsx : f7a0ac74c2cb5d3f558e45168a539bad9357a744
router]: at=info method=POST path="/v2/watermark" host=propel-document-staging.herokuapp.com request_id=12681e01-28c0-47f8-842b-3d28bd7096c4 fwd="98.234.38.231" dyno=web.1 connect=0ms service=1ms status=200 bytes=209 protocol=https
[web.1]: >>> convert : Logs.xlsx : 3ee1fa89cd98b47ba9f2c982dd72c9670162cf65
[web.1]: >>> convert : Logs.xlsx : 58fe98dcf85926778b386b253a148a8fb764104e
router]: at=info method=POST path="/v2/watermark" host=propel-document-staging.herokuapp.com request_id=a1c6edff-ef48-436b-9af8-8c593c713f27 fwd="98.234.38.231" dyno=web.1 connect=0ms service=2ms status=200 bytes=209 protocol=https
[web.1]: >>> watermark : Logs.xlsx : cf77a369a2c59438c2c95b5865b75b674445360f
[web.1]: >>> upload : Logs.xlsx : cf77a369a2c59438c2c95b5865b75b674445360f
[web.1]: >>> watermark : Logs.xlsx : 58fe98dcf85926778b386b253a148a8fb764104e
[web.1]: >>> upload : Logs.xlsx : 58fe98dcf85926778b386b253a148a8fb764104e
[web.1]: >>> watermark : Logs.xlsx : 24bbf9769712877d3184480820586185c5008239
[web.1]: >>> upload : Logs.xlsx : 24bbf9769712877d3184480820586185c5008239
[web.1]: >>> watermark : Logs.xlsx : f7a0ac74c2cb5d3f558e45168a539bad9357a744
[web.1]: >>> upload : Logs.xlsx : f7a0ac74c2cb5d3f558e45168a539bad9357a744
[web.1]: >>> watermark : Logs.xlsx : 3ee1fa89cd98b47ba9f2c982dd72c9670162cf65
[web.1]: >>> upload : Logs.xlsx : 3ee1fa89cd98b47ba9f2c982dd72c9670162cf65
[web.1]: failed_to_download. try count: 2 : 4f1ea591f0f110a2377b9f79a5232aaecfac7071.xlsx
[web.1]: failed_to_download. try count: 2 : 2a3f5c8db2a0c06dad8988ab5e0a3c08798ce3d7.xlsx
[web.1]: failed_to_download. try count: 2 : b510db7dccc212e4d8e2933b85cf6aed4cc1a86d.xlsx
[web.1]: failed_to_download. try count: 2 : c6928e0624b67ba2961e911da8b6ae8499ba8368.xlsx
[web.1]: failed_to_download. try count: 2 : 416eb9f55f29bfba2bf072ca8ae02c616098f803.xlsx
[web.1]: failed_to_download. try count: 3 : 4f1ea591f0f110a2377b9f79a5232aaecfac7071.xlsx
[web.1]: Error: failed_to_download_too_many_tries
[web.1]:     at Watermark.convertDoc (/app/api/v2/lib/Watermark.js:96:17)
[web.1]: failed_to_download. try count: 3 : 2a3f5c8db2a0c06dad8988ab5e0a3c08798ce3d7.xlsx
[web.1]: Error: failed_to_download_too_many_tries
[web.1]:     at Watermark.convertDoc (/app/api/v2/lib/Watermark.js:96:17)
[web.1]: failed_to_download. try count: 3 : b510db7dccc212e4d8e2933b85cf6aed4cc1a86d.xlsx
[web.1]: Error: failed_to_download_too_many_tries
[web.1]:     at Watermark.convertDoc (/app/api/v2/lib/Watermark.js:96:17)
[web.1]: failed_to_download. try count: 3 : c6928e0624b67ba2961e911da8b6ae8499ba8368.xlsx
[web.1]: Error: failed_to_download_too_many_tries
[web.1]:     at Watermark.convertDoc (/app/api/v2/lib/Watermark.js:96:17)
[web.1]: failed_to_download. try count: 3 : 416eb9f55f29bfba2bf072ca8ae02c616098f803.xlsx
[web.1]: Error: failed_to_download_too_many_tries
[web.1]:     at Watermark.convertDoc (/app/api/v2/lib/Watermark.js:96:17)
```